### PR TITLE
Added requisite parenthese to print() in example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ s.mapfn = mapfn
 s.reducefn = reducefn
 
 results = s.run_server(password="changeme")
-print results
+print(results)
 ```
 
 Execute this script on the server:

--- a/example.py
+++ b/example.py
@@ -23,4 +23,4 @@ s.mapfn = mapfn
 s.reducefn = reducefn
 
 results = s.run_server(password="changeme")
-print results
+print(results)


### PR DESCRIPTION
A quick change to the example and the readme so the example works out of the box.  Print changed in Python3 per <a href='http://docs.python.org/3.0/whatsnew/3.0.html#print-is-a-function'>http://docs.python.org/3.0/whatsnew/3.0.html#print-is-a-function</a>.

Fixes the following syntax error:
$ python3 example.py 
  File "example.py", line 26
    print results
                ^
SyntaxError: invalid syntax
